### PR TITLE
Fix Application.isUsingHardware() doesnt compile on HTML5

### DIFF
--- a/src/openfl/display/Application.hx
+++ b/src/openfl/display/Application.hx
@@ -7,8 +7,10 @@ import openfl.display.MovieClip;
 
 #if (lime >= "7.0.0")
 import lime.ui.WindowAttributes;
+#if mobile
 @:access(lime.ui.Window)
 @:access(lime._internal.backend.native.NativeWindow)
+#end
 #else
 import lime.app.Config;
 #end
@@ -143,7 +145,11 @@ class Application extends LimeApplication {
 	}
 	
 	public function isUsingHardware():Bool {
+		#if mobile
 		return __window.__backend.useHardware;
+		#else
+		return true;
+		#end
 	}
 	#end
 	


### PR DESCRIPTION
In a previous commit a made a new function `Application.isUsingHardware()` to expose NativeWindow.userHardware to application code, however I forgot to handle other platforms that does not use NativeWindow. This PR fixes the issue.